### PR TITLE
lesson: 2-13 고아객체 실습 및 테스트

### DIFF
--- a/src/main/java/com/sparta/jpaadvance/entity/User.java
+++ b/src/main/java/com/sparta/jpaadvance/entity/User.java
@@ -3,6 +3,7 @@ package com.sparta.jpaadvance.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.action.internal.OrphanRemovalAction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,7 +21,9 @@ public class User {
     // 원투매니 속성 중 fetch 디폴트 lazy(지연로딩)
     // 뒤가 Many이면 리스트로 조회를 하게 되기에 지연로딩이 디폴트
     // 영속성전이 cascade.persist, 삭제할 시는 cascade.remove
-    @OneToMany(mappedBy = "user",  cascade = {CascadeType.REMOVE, CascadeType.PERSIST})
+    // orphanRomoval의 디폴트는 false이고 cascade.remove의 옵션과 비슷하나 orphanremoval은 연관관계만 끊겨도 삭제된다
+    // @ManyToOne은 orphanRemoval이 없다 -> Many이기에 연관관계가 설정된 레코드가 있을 수 있기 때문에
+    @OneToMany(mappedBy = "user",  cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<Food> foodList = new ArrayList<>();
 
     public void addFoodList(Food food) {

--- a/src/test/java/com/sparta/jpaadvance/orphan/OrphanTest.java
+++ b/src/test/java/com/sparta/jpaadvance/orphan/OrphanTest.java
@@ -1,0 +1,99 @@
+package com.sparta.jpaadvance.orphan;
+
+import com.sparta.jpaadvance.entity.Food;
+import com.sparta.jpaadvance.entity.User;
+import com.sparta.jpaadvance.repository.FoodRepository;
+import com.sparta.jpaadvance.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SpringBootTest
+public class OrphanTest {
+
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    FoodRepository foodRepository;
+
+    @Test
+    @Transactional
+    @Rollback(value = false)
+    void init() {
+        List<User> userList = new ArrayList<>();
+        User user1 = new User();
+        user1.setName("Robbie");
+        userList.add(user1);
+
+        User user2 = new User();
+        user2.setName("Robbert");
+        userList.add(user2);
+        userRepository.saveAll(userList);
+
+        List<Food> foodList = new ArrayList<>();
+        Food food1 = new Food();
+        food1.setName("고구마 피자");
+        food1.setPrice(30000);
+        food1.setUser(user1); // 외래 키(연관 관계) 설정
+        foodList.add(food1);
+
+        Food food2 = new Food();
+        food2.setName("아보카도 피자");
+        food2.setPrice(50000);
+        food2.setUser(user1); // 외래 키(연관 관계) 설정
+        foodList.add(food2);
+
+        Food food3 = new Food();
+        food3.setName("후라이드 치킨");
+        food3.setPrice(15000);
+        food3.setUser(user1); // 외래 키(연관 관계) 설정
+        foodList.add(food3);
+
+        Food food4 = new Food();
+        food4.setName("양념 치킨");
+        food4.setPrice(20000);
+        food4.setUser(user2); // 외래 키(연관 관계) 설정
+        foodList.add(food4);
+
+        Food food5 = new Food();
+        food5.setName("고구마 피자");
+        food5.setPrice(30000);
+        food5.setUser(user2); // 외래 키(연관 관계) 설정
+        foodList.add(food5);
+        foodRepository.saveAll(foodList);
+    }
+
+    @Test
+    @Transactional
+    @Rollback(value = false)
+    @DisplayName("연관관계 제거")
+    void test1() {
+        // 고객 Robbie 를 조회합니다.
+        User user = userRepository.findByName("Robbie");
+        System.out.println("user.getName() = " + user.getName());
+
+        // 연관된 음식 Entity 제거 : 후라이드 치킨
+        Food chicken = null;
+        for (Food food : user.getFoodList()) {
+            if(food.getName().equals("후라이드 치킨")) {
+                chicken = food;
+            }
+        }
+        if(chicken != null) {
+            user.getFoodList().remove(chicken);
+        }
+
+        // 연관관계 제거 확인
+        for (Food food : user.getFoodList()) {
+            System.out.println("food.getName() = " + food.getName());
+        }
+        // 제거시도를 하였으나 후라이드치킨이 아직 DB에 존재
+        // orphanRemoval = true옵션을 넣어주면 삭제
+    }
+}


### PR DESCRIPTION
- close #29 
- 테스트 완료
- @ManyToOne에는 고아객체를 사용할 수 없다 -> 다른 연관관계가 설정되어 있을 수 있기 때문에
- orphanRemoval = true와 CascadeType = cascade = REMOVE는 다르다
- 고아객체는 삭제를 안하더라고 연관관계가 끊어지면 자동삭제가 되며 REMOVE는 부모를 삭제할 때 자식도 삭제되는 설정이다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 사용자 식품 목록에서 항목을 제거하면 연관된 데이터가 자동으로 삭제되어 고아 레코드가 남지 않도록 수정했습니다.
  - 저장/삭제 전파 동작을 단순화해 예기치 않은 일괄 삭제 가능성을 줄였습니다.

- **Tests**
  - 고아 객체 자동 삭제 동작을 검증하는 통합 테스트를 추가했습니다(초기 데이터 세팅, 항목 제거 검증).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->